### PR TITLE
INTERNAL: Fix a smget handling about trimmed result without bkey

### DIFF
--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -425,7 +425,7 @@ merge_smget_results(memcached_coll_smget_result_st **results,
   memset(result_idx, 0, 256*sizeof(size_t));
 
   memcached_coll_sub_key_st *prev_sub_key = NULL;
-  memcached_coll_sub_key_st *curr_sub_key;
+  memcached_coll_sub_key_st *curr_sub_key = NULL;
 
   size_t merged_count= 0;
   size_t found_count= 0;
@@ -627,7 +627,7 @@ merge_smget_results(memcached_coll_smget_result_st **results,
   for (size_t i=0; i<merged->trimmed_key_count; i++)
   {
     int smallest_idx= -1;
-    int comp_result;
+    int comp_result= 0;
     bool should_merge= false;
     for (size_t j=0; j<num_results; j++)
     {
@@ -666,15 +666,17 @@ merge_smget_results(memcached_coll_smget_result_st **results,
 
     if (merged->value_count < merged->count)
     {
-      /* compare it with the bkey of the last found element */
-      prev_sub_key = &merged->sub_keys[merged->value_count-1];
-      curr_sub_key = &results[smallest_idx]->trimmed_sub_keys[result_idx[smallest_idx]];
-      if (byte_array_bkey) {
-        comp_result= memcached_compare_two_hexadecimal(&prev_sub_key->bkey_ext,
-                                                       &curr_sub_key->bkey_ext);
-      } else {
-        comp_result= (prev_sub_key->bkey == curr_sub_key->bkey) ? 0
-                   : (prev_sub_key->bkey <  curr_sub_key->bkey) ? -1 : 1;
+      if (merged->value_count > 0) {
+        /* compare it with the bkey of the last found element */
+        prev_sub_key = &merged->sub_keys[merged->value_count-1];
+        curr_sub_key = &results[smallest_idx]->trimmed_sub_keys[result_idx[smallest_idx]];
+        if (byte_array_bkey) {
+          comp_result= memcached_compare_two_hexadecimal(&prev_sub_key->bkey_ext,
+                                                         &curr_sub_key->bkey_ext);
+        } else {
+          comp_result= (prev_sub_key->bkey == curr_sub_key->bkey) ? 0
+                     : (prev_sub_key->bkey <  curr_sub_key->bkey) ? -1 : 1;
+        }
       }
       if (comp_result <= 0) {
           should_merge= true;
@@ -759,6 +761,8 @@ memcached_coll_smget_fetch_result(memcached_st *ptr,
         *error= MEMCACHED_MEMORY_ALLOCATION_FAILURE;
         break;
       }
+
+      each_result->sub_key_type = result->sub_key_type;
     }
 
     char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];

--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -255,12 +255,12 @@ static void textual_switchover_peer_check(memcached_server_write_instance_st ins
   if (str_length < buf_length) {
     /* OK */
     memcpy(instance->switchover_peer, startptr, str_length);
-    instance->switchover_peer[str_length]= '\0'; 
+    instance->switchover_peer[str_length]= '\0';
     instance->switchover_sidx= -1; /* undefined */
   } else {
     /* something is wrong */
     memcpy(instance->switchover_peer, startptr, buf_length-1);
-    instance->switchover_peer[buf_length-1]= '\0'; 
+    instance->switchover_peer[buf_length-1]= '\0';
     instance->switchover_sidx= 1; /* set first slave */
   }
 }
@@ -2002,12 +2002,17 @@ static memcached_return_t textual_coll_smget_value_fetch(memcached_server_write_
       /* byte array bkey : starts with 0x */
       if (to_read_string[0] == '0' && to_read_string[1] == 'x')
       {
+        if (result->sub_key_type != MEMCACHED_COLL_QUERY_BOP_EXT &&
+            result->sub_key_type != MEMCACHED_COLL_QUERY_BOP_EXT_RANGE)
+            return MEMCACHED_PROTOCOL_ERROR;
         memcached_conv_str_to_hex(ptr->root, to_read_string+2, read_length-2-1, &result->sub_keys[i].bkey_ext); // except '0x' and '\0'
-        result->sub_key_type = MEMCACHED_COLL_QUERY_BOP_EXT;
       }
       /* normal bkey */
       else
       {
+        if (result->sub_key_type != MEMCACHED_COLL_QUERY_BOP &&
+            result->sub_key_type != MEMCACHED_COLL_QUERY_BOP_RANGE)
+            return MEMCACHED_PROTOCOL_ERROR;
         result->sub_keys[i].bkey = strtoull(to_read_string, &string_ptr, 10);
         result->sub_key_type = MEMCACHED_COLL_QUERY_BOP;
       }
@@ -2280,7 +2285,8 @@ static memcached_return_t textual_coll_smget_trimmed_key_fetch(memcached_server_
     {
       memcached_conv_str_to_hex(ptr->root, to_read_string+2, read_length-2-1,
                                 &result->trimmed_sub_keys[i].bkey_ext); // except '0x' and '\0'
-      if (result->sub_key_type != MEMCACHED_COLL_QUERY_BOP_EXT)
+      if (result->sub_key_type != MEMCACHED_COLL_QUERY_BOP_EXT &&
+          result->sub_key_type != MEMCACHED_COLL_QUERY_BOP_EXT_RANGE)
       {
         memcached_string_free(&result->trimmed_keys[i]);
         return MEMCACHED_PROTOCOL_ERROR;
@@ -2290,7 +2296,8 @@ static memcached_return_t textual_coll_smget_trimmed_key_fetch(memcached_server_
     else
     {
       result->trimmed_sub_keys[i].bkey = strtoull(to_read_string, &string_ptr, 10);
-      if (result->sub_key_type != MEMCACHED_COLL_QUERY_BOP)
+      if (result->sub_key_type != MEMCACHED_COLL_QUERY_BOP &&
+          result->sub_key_type != MEMCACHED_COLL_QUERY_BOP_RANGE)
       {
         memcached_string_free(&result->trimmed_keys[i]);
         return MEMCACHED_PROTOCOL_ERROR;


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#480

### ⌨️ What I did
- smget(new) 연산 시 VALUE 결과가 0인 경우 merge과정에서 비교 연산을 수행하지 않게 끔 변경했습니다.
- 서버에서 받은 모든 bkey type에 대해 사용자가 입력한 bkey type과 다를 경우 `PROTOCOL_ERROR`를 반환하도록 변경했습니다.
  - (기존) Value에서 받은 element의 bkey type과  trimmed key에서의 bkey type이 다른 경우 `PROTOCOL_ERROR`를 반환
- 일부 uninitialized variable error를 수정했습니다.

### 🤔 Others
- 서버의 Response 메시지
  ```
  ELEMENTS 0
  MISSED_KEYS 0
  TRIMMED_KEYS 1
  b 201
  END
  ```
- 변경된 반환 결과
  - 기존
  ```
  memcached smget(new) result : PROTOCOL ERROR, response : PROTOCOL ERROR
  ```
  - 변경
  ```
  memcached smget(new) result : SUCCESS, response : SERVER END
  ```